### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ A curated list of awesome malware analysis tools and resources. Inspired by
 
 * [Autoshun](http://autoshun.org/) ([list](http://autoshun.org/files/shunlist.csv)) -
   Snort plugin and blocklist.
-* [CI Army](http://www.ciarmy.com/) ([list](http://www.ciarmy.com/list/ci-badguys.txt)) -
+* [CI Army](http://cinsscore.com/) ([list](http://cinsscore.com/list/ci-badguys.txt)) -
   Network security blocklists.
 * [Critical Stack- Free Intel Market](https://intel.CriticalStack.com) - Free
   intel aggregator with deduplication featuring 90+ feeds and over 1.2M indicators.


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### Corrected URLs 
Was | Now 
--- | --- 
http://www.ciarmy.com/ | http://cinsscore.com/ 
http://www.ciarmy.com/list/ci-badguys.txt | http://cinsscore.com/list/ci-badguys.txt 

The following redirected URLs were left unchanged

Was | Now 
--- | --- 
http://honeydrive.org/ | http://bruteforce.gr/honeydrive
http://mitre.org | http://www.mitre.org/
http://cybox.mitre.org/ | http://cyboxproject.github.io
http://stix.mitre.org/ | http://stixproject.github.io
http://taxii.mitre.org/ | http://taxiiproject.github.io
http://totalhash.com/ | https://totalhash.cymru.com/
https://regripper.wordpress.com/ | http://brettshavers.cc/index.php/brettsblog/tags/tag/regripper/
