### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ A curated list of awesome malware analysis tools and resources. Inspired by
   malware.
 * [Glastopf](http://glastopf.org/) - Web application honeypot.
 * [Honeyd](http://honeyd.org/) - Create a virtual honeynet.
-* [HoneyDrive](http://honeydrive.org/) - Honeypot bundle Linux distro.
+* [HoneyDrive](http://bruteforce.gr/honeydrive) - Honeypot bundle Linux distro.
 * [Kippo](https://github.com/desaster/kippo) - Medium interaction SSH honeypot.
 * [Mnemosyne](https://github.com/johnnykv/mnemosyne) - A normalizer for
   honeypot data; supports Dionaea.
@@ -130,7 +130,7 @@ A curated list of awesome malware analysis tools and resources. Inspired by
 
 * [Autoshun](http://autoshun.org/) ([list](http://autoshun.org/files/shunlist.csv)) -
   Snort plugin and blocklist.
-* [CI Army](http://www.ciarmy.com/) ([list](http://www.ciarmy.com/list/ci-badguys.txt)) -
+* [CI Army](http://www.ciarmy.com/) ([list](http://cinsscore.com/list/ci-badguys.txt)) -
   Network security blocklists.
 * [Critical Stack- Free Intel Market](https://intel.CriticalStack.com) - Free
   intel aggregator with deduplication featuring 90+ feeds and over 1.2M indicators.
@@ -149,13 +149,13 @@ A curated list of awesome malware analysis tools and resources. Inspired by
 * [OpenIOC](http://openioc.org/) - Framework for sharing threat intelligence.
 * [Palevo Blocklists](https://palevotracker.abuse.ch/blocklists.php) - Botnet
   C&C blocklists.
-* [STIX - Structured Threat Information eXpression](http://stix.mitre.org/) -
+* [STIX - Structured Threat Information eXpression](http://stixproject.github.io) -
   Standardized language to represent and share cyber threat information.
-  Related efforts from [MITRE](http://mitre.org):
+  Related efforts from [MITRE](http://www.mitre.org/):
   - [CAPEC - Common Attack Pattern Enumeration and Classification](http://capec.mitre.org/)
-  - [CybOX - Cyber Observables eXpression](http://cybox.mitre.org/)
+  - [CybOX - Cyber Observables eXpression](http://cyboxproject.github.io)
   - [MAEC - Malware Attribute Enumeration and Characterization](http://maec.mitre.org/)
-  - [TAXII - Trusted Automated eXchange of Indicator Information](http://taxii.mitre.org/)
+  - [TAXII - Trusted Automated eXchange of Indicator Information](http://taxiiproject.github.io)
 * [threatRECON](https://threatrecon.co/) - Search for indicators, up to 1000
   free per month.
 * [Yara rules](https://github.com/Yara-Rules/rules) - Yara rules repository.
@@ -192,7 +192,7 @@ A curated list of awesome malware analysis tools and resources. Inspired by
 * [Rootkit Hunter](http://rkhunter.sourceforge.net/) - Detect Linux rootkits.
 * [ssdeep](http://ssdeep.sourceforge.net/) - Compute fuzzy hashes.
 * [totalhash.py](https://gist.github.com/malc0de/10270150) - Python script
-  for easy searching of the [TotalHash.com](http://totalhash.com/) database.
+  for easy searching of the [TotalHash.com](https://totalhash.cymru.com/) database.
 * [TrID](http://mark0.net/soft-trid-e.html) - File identifier.
 * [YARA](https://plusvic.github.io/yara/) - Pattern matching tool for
   analysts.
@@ -488,7 +488,7 @@ the [browser malware](#browser-malware) section.*
   library for parsing Windows Event Logs.
 * [python-registry](http://www.williballenthin.com/registry/) - Python
   library for parsing registry files.
-* [RegRipper](https://regripper.wordpress.com/)
+* [RegRipper](http://brettshavers.cc/index.php/brettsblog/tags/tag/regripper/)
   ([GitHub](https://github.com/keydet89/RegRipper2.8)) -
   Plugin-based registry analysis tool.
 


### PR DESCRIPTION
Replacing all HTTP redirects

🔶  8 redirects
http://honeydrive.org/ redirects to 
http://bruteforce.gr/honeydrive 

http://www.ciarmy.com/list/ci-badguys.txt redirects to 
http://cinsscore.com/list/ci-badguys.txt 

http://stix.mitre.org/ redirects to 
http://stixproject.github.io 

http://cybox.mitre.org/ redirects to 
http://cyboxproject.github.io 

http://mitre.org redirects to 
http://www.mitre.org/ 

http://taxii.mitre.org/ redirects to 
http://taxiiproject.github.io 

http://totalhash.com/ redirects to 
https://totalhash.cymru.com/  

https://regripper.wordpress.com/ redirects to 
http://brettshavers.cc/index.php/brettsblog/tags/tag/regripper/  