### PR TITLE
Add link to PREDICT

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ A curated list of awesome malware analysis tools and resources. Inspired by
 * [OpenIOC](http://openioc.org/) - Framework for sharing threat intelligence.
 * [Palevo Blocklists](https://palevotracker.abuse.ch/blocklists.php) - Botnet
   C&C blocklists.
+* [PREDICT](https://predict.org/default.aspx?cs_Category=2) - Protected
+Repository for the Defense of Infrastructure Against Cyber Threats (PREDICT)
+can quickly and easily provide qualified developers and evaluators with
+regularly updated network operations data they can use in their cyber security
+research.
 * [Proofpoint Threat Intelligence (formerly Emerging Threats)](https://www.proofpoint.com/us/threat-intelligence-overview) -
   Rulesets and more.
 * [STIX - Structured Threat Information eXpression](http://stixproject.github.io) -
@@ -241,7 +246,7 @@ A curated list of awesome malware analysis tools and resources. Inspired by
 * [PDF Examiner](http://www.pdfexaminer.com/) - Analyse suspicious PDF files.
 * [Recomposer](https://github.com/secretsquirrel/recomposer) - A helper
   script for safely uploading binaries to sandbox sites.
-* [SEE](https://github.com/F-Secure/see) - Sandboxed Execution Environment (SEE) 
+* [SEE](https://github.com/F-Secure/see) - Sandboxed Execution Environment (SEE)
   is a framework for building test automation in secured Environments.
 * [VirusTotal](https://www.virustotal.com/) - Free online analysis of malware
   samples and URLs
@@ -446,8 +451,8 @@ the [browser malware](#browser-malware) section.*
   building a malware lab.
 * [Malcom](https://github.com/tomchop/malcom) - Malware Communications
   Analyzer.
-* [Maltrail](https://github.com/stamparm/maltrail) - A malicious traffic 
-  detection system, utilizing publicly available (black)lists containing 
+* [Maltrail](https://github.com/stamparm/maltrail) - A malicious traffic
+  detection system, utilizing publicly available (black)lists containing
   malicious and/or generally suspicious trails and featuring an reporting
   and analysis interface.
 * [mitmproxy](https://mitmproxy.org/) - Intercept network traffic on the fly.
@@ -577,7 +582,7 @@ the [browser malware](#browser-malware) section.*
 * [Malware Samples and Traffic](http://malware-traffic-analysis.net/) - This
   blog focuses on network traffic related to malware infections.
 * [RPISEC Malware Analysis](https://github.com/RPISEC/Malware) - These are the
-  course materials used in the Malware Analysis course at at Rensselaer Polytechnic 
+  course materials used in the Malware Analysis course at at Rensselaer Polytechnic
   Institute during Fall 2015.
 
 # Related Awesome Lists


### PR DESCRIPTION
Add link to the Protected Repository for the Defense of Infrastructure
Against Cyber Threats ([PREDICT](https://predict.org)), that can
quickly and easily provide qualified developers and evaluators with
regularly updated network operations data they can use in their cyber
security research.