### PR TITLE
Add RetDec

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,9 @@ the [browser malware](#browser-malware) section.*
   analysis.
 * [Radare2](http://www.radare.org/r/) - Reverse engineering framework, with
   debugger support.
+* [RetDec](https://retdec.com/) - Retargetable machine-code decompiler with an
+  [online decompilation service](https://retdec.com/decompilation/) and
+  [API](https://retdec.com/api/) that you can use in your tools.
 * [ROPMEMU](https://github.com/vrtadmin/ROPMEMU) - A framework to analyze, dissect
   and decompile complex code-reuse attacks.
 * [SMRT](https://github.com/pidydx/SMRT) - Sublime Malware Research Tool, a


### PR DESCRIPTION
[RetDec](https://retdec.com/) is a retargetable machine-code decompiler with an [online decompilation service](https://retdec.com/decompilation/) and [API](https://retdec.com/api/) that you can use in your tools.

The online decompilation service can be used without any registration. To use the API, you have to register to obtain an API key, but other than that it is free to use.

Full disclosure: I am part of the RetDec development team and author of several libraries for accessing the API in various languages (e.g. [retdec-python](https://github.com/s3rvac/retdec-python)).
