### PR TITLE
Replace maltrieve with Ragpicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,12 @@ A curated list of awesome malware analysis tools and resources. Inspired by
   samples.
 * [Malshare](http://malshare.com) - Large repository of malware actively
   scrapped from malicious sites.
-* [maltrieve](https://github.com/krmaxwell/maltrieve) - Retrieve malware
   samples directly from a number of online sources.
 * [MalwareDB](http://malwaredb.malekal.com/) - Malware samples repository.
 * [Open Malware Project](http://openmalware.org/) - Sample information and
   downloads. Formerly Offensive Computing.
+* [Ragpicker](https://github.com/robbyFux/Ragpicker) - Plugin based malware
+  crawler with pre-analysis and reporting functionalities
 * [theZoo](https://github.com/ytisf/theZoo) - Live malware samples for
   analysts.
 * [ViruSign](http://www.virusign.com/) - Malware database that detected by


### PR DESCRIPTION
As the maintainer of [maltrieve](https://github.com/krmaxwell/maltrieve), I suggest removing it as it is dormant / deprecated. However, [Ragpicker](https://github.com/robbyFux/Ragpicker) seems to be based in part on some of the same code and does *way* more.,