### PR TITLE
Added Kaitai Struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,9 @@ the [browser malware](#browser-malware) section.*
   disassembler and debugger, with a free evaluation version.
 * [Immunity Debugger](http://debugger.immunityinc.com/) - Debugger for
   malware analysis and more, with a Python API.
+* [Kaitai Struct](http://kaitai.io/) - DSL for file formats / network protocols /
+  data structures reverse engineering and dissection, with code generation
+  for C++, C#, Java, JavaScript, Perl, PHP, Python, Ruby.
 * [ltrace](http://ltrace.org/) - Dynamic analysis for Linux executables.
 * [objdump](https://en.wikipedia.org/wiki/Objdump) - Part of GNU binutils,
   for static analysis of Linux binaries.


### PR DESCRIPTION
I'm proposing to add awesome Kaitai Struct — a domain-specific language designed for arbitrary binary file format parsing. It is useful for "black box" reverse engineering of unknown binary formats and for quick inspection of details of known binary formats (like PE, ELF, Mach-O, JPEG, PNG, TIFF, Windows registry files, etc).

Last, but not least, there is a reference compiler that compiles Kaitai Struct file format specs into ready-made parsing libraries in multitude of programming languages, to be used straight away programmatically.

I'm not 100% sure about the category, but probably it's best to just put it into general "reverse engineering" category. It can be compared to Hachoir (which is now in "File Carving"), or to Bro, Wireshark and chopshop (which are obviously in "Network").