### PR TITLE
Propose QKD debugging tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,7 @@ the [browser malware](#browser-malware) section.*
   command-line tools that help manage and investigate live systems.
 * [Pyew](https://github.com/joxeankoret/pyew) - Python tool for malware
   analysis.
+* [QKD](https://github.com/ispras/qemu/releases/tag/v2.7.50-windbg) - QEMU with embedded WinDbg server for stealth debugging
 * [Radare2](http://www.radare.org/r/) - Reverse engineering framework, with
   debugger support.
 * [RegShot](https://sourceforge.net/projects/regshot/) - Registry compare utility that compares snapshots. 

--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ the [browser malware](#browser-malware) section.*
   command-line tools that help manage and investigate live systems.
 * [Pyew](https://github.com/joxeankoret/pyew) - Python tool for malware
   analysis.
-* [QKD](https://github.com/ispras/qemu/releases/tag/v2.7.50-windbg) - QEMU with embedded WinDbg server for stealth debugging
+* [QKD](https://github.com/ispras/qemu/releases/) - QEMU with embedded WinDbg server for stealth debugging.
 * [Radare2](http://www.radare.org/r/) - Reverse engineering framework, with
   debugger support.
 * [RegShot](https://sourceforge.net/projects/regshot/) - Registry compare utility that compares snapshots. 


### PR DESCRIPTION
QKD - QEMU with embedded WinDbg module.
It enables Windows kernel debugging without turning Windows debug mode on.
WinDbg obtains all necessary information from the emulator.