### PR TITLE
Add HaboMalHunter

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ YARA rules.
   system.
 * [File Analyzer](https://www.file-analyzer.net/) - Free dynamic analysis of PE files.
 * [firmware.re](http://firmware.re/) - Unpacks, scans and analyzes almost any firmware package.
+* [HaboMalHunter](https://github.com/Tencent/HaboMalHunter) - An Automated Malware Analysis Tool for Linux ELF Files.
 * [Hybrid Analysis](https://www.hybrid-analysis.com/) - Online malware
   analysis tool, powered by VxSandbox.
 * [IRMA](http://irma.quarkslab.com/) - An asynchronous and customizable

--- a/恶意软件分析大合集.md
+++ b/恶意软件分析大合集.md
@@ -1,4 +1,4 @@
-﻿# 恶意软件分析大合集
+# 恶意软件分析大合集
 
 
 这个列表记录着那些令人称赞的恶意软件分析工具和资源。受到 [awesome-python](https://github.com/vinta/awesome-python) 和 [awesome-php](https://github.com/ziadoz/awesome-php) 的启迪。
@@ -172,6 +172,7 @@
 * [DRAKVUF](https://github.com/tklengyel/drakvuf) - 动态恶意软件分析系统
 * [File Analyzer](https://www.file-analyzer.net/) - 免费 PE 文件动态分析
 * [firmware.re](http://firmware.re/) - 解包、扫描、分析绝大多数固件包
+* [HaboMalHunter](https://github.com/Tencent/HaboMalHunter) - Linux平台上的自动化恶意代码分析工具.
 * [Hybrid Analysis](https://www.hybrid-analysis.com/) - 由 VxSandbox 支持的在线恶意软件分析工具
 * [IRMA](http://irma.quarkslab.com/) - 异步、可定制的可疑文件分析平台
 * [Joe Sandbox](https://www.joesecurity.org/) - 深度恶意软件分析


### PR DESCRIPTION
HaboMalHunter is an open-sourced Linux malware analysis tool, which was presented in BlackHat ASIA 2017 Arsenal.
More information can be found at [here](https://www.blackhat.com/asia-17/arsenal.html#habomalhunter-an-automated-malware-analysis-tool-for-linux-elf-files).

Thanks.


