### PR TITLE
Add HashCheck.

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ A curated list of awesome malware analysis tools and resources. Inspired by
   Modular, recursive file scanning solution.
 * [hashdeep](https://github.com/jessek/hashdeep) - Compute digest hashes with
   a variety of algorithms.
+* [HashCheck](https://github.com/gurnec/HashCheck) - Windows shell extension
+  to compute hashes with a variety of algorithms.
 * [Loki](https://github.com/Neo23x0/Loki) - Host based scanner for IOCs.
 * [Malfunction](https://github.com/Dynetics/Malfunction) - Catalog and
   compare malware at a function level.


### PR DESCRIPTION
Add HashCheck because it's quicker and simpler than some CLI alternatives. It also has more stars on Github than hashdeep does.