### PR TITLE
Broke ngrep link

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ the [browser malware](#browser-malware) section.*
   and database system.
 * [NetworkMiner](http://www.netresec.com/?page=NetworkMiner) - Network
   forensic analysis tool, with a free version.
-* [ngrep](http://ngrep.sourceforge.net/) - Search through network traffic
+* [ngrep](https://github.com/jpr5/ngrep) - Search through network traffic
   like grep.
 * [PcapViz](https://github.com/mateuszk87/PcapViz) - Network topology and
   traffic visualizer.


### PR DESCRIPTION
The ngrep link is broke. Looks like it may be hosted on GitHub now.