### PR TITLE
remove http://malwaredb.malekal.com/ and add SystemLookup and Malware…

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ View Chinese translation: [恶意软件分析大合集.md](恶意软件分析大
 
 * [Conpot](https://github.com/mushorg/conpot) - ICS/SCADA honeypot.
 * [Cowrie](https://github.com/micheloosterhof/cowrie) - SSH honeypot, based
-  on Kippo.  
-* [DemoHunter](https://github.com/RevengeComing/DemonHunter) - Low interaction Distributed Honeypots.  
-* [Dionaea](https://github.com/DinoTools/dionaea) - Honeypot designed to trap malware.   
+  on Kippo.
+* [DemoHunter](https://github.com/RevengeComing/DemonHunter) - Low interaction Distributed Honeypots.
+* [Dionaea](https://github.com/DinoTools/dionaea) - Honeypot designed to trap malware.
 * [Glastopf](https://github.com/mushorg/glastopf) - Web application honeypot.
 * [Honeyd](http://www.honeyd.org/) - Create a virtual honeynet.
 * [HoneyDrive](http://bruteforcelab.com/honeydrive) - Honeypot bundle Linux distro.
@@ -78,11 +78,10 @@ View Chinese translation: [恶意软件分析大合集.md](恶意软件分析大
 * [Exploit Database](https://www.exploit-db.com/) - Exploit and shellcode
   samples.
 * [Infosec - CERT-PA](https://infosec.cert-pa.it/analyze/submission.html) - Malware samples collection and analysis.
-* [Malpedia](https://malpedia.caad.fkie.fraunhofer.de/) - A resource providing 
+* [Malpedia](https://malpedia.caad.fkie.fraunhofer.de/) - A resource providing
   rapid identification and actionable context for malware investigations.
 * [Malshare](https://malshare.com) - Large repository of malware actively
   scrapped from malicious sites.
-* [MalwareDB](http://malwaredb.malekal.com/) - Malware samples repository.
 * [Open Malware Project](http://openmalware.org/) - Sample information and
   downloads. Formerly Offensive Computing.
 * [Ragpicker](https://github.com/robbyFux/Ragpicker) - Plugin based malware
@@ -192,12 +191,14 @@ View Chinese translation: [恶意软件分析大合集.md](恶意软件分析大
   - [CybOX - Cyber Observables eXpression](http://cyboxproject.github.io)
   - [MAEC - Malware Attribute Enumeration and Characterization](http://maec.mitre.org/)
   - [TAXII - Trusted Automated eXchange of Indicator Information](http://taxiiproject.github.io)
+* [SystemLookup](https://www.systemlookup.com/) - SystemLookup hosts a collection of lists that provide information on
+  the components of legitimate and potentially unwanted programs.
 * [ThreatMiner](https://www.threatminer.org/) - Data mining portal for threat
   intelligence, with search.
 * [threatRECON](https://threatrecon.co/) - Search for indicators, up to 1000
   free per month.
 * [Yara rules](https://github.com/Yara-Rules/rules) - Yara rules repository.
-* [YETI](https://github.com/yeti-platform/yeti) - Yeti is a platform meant to organize observables, indicators of compromise, TTPs, and knowledge on threats in a single, unified repository. 
+* [YETI](https://github.com/yeti-platform/yeti) - Yeti is a platform meant to organize observables, indicators of compromise, TTPs, and knowledge on threats in a single, unified repository.
 * [ZeuS Tracker](https://zeustracker.abuse.ch/blocklist.php) - ZeuS
   blocklists.
 
@@ -207,7 +208,7 @@ View Chinese translation: [恶意软件分析大合集.md](恶意软件分析大
 
 * [AnalyzePE](https://github.com/hiddenillusion/AnalyzePE) - Wrapper for a
   variety of tools for reporting on Windows PE files.
-* [Assemblyline](https://bitbucket.org/cse-assemblyline/assemblyline) - A scalable 
+* [Assemblyline](https://bitbucket.org/cse-assemblyline/assemblyline) - A scalable
   distributed file analysis framework.
 * [BinaryAlert](https://github.com/airbnb/binaryalert) - An open source, serverless
   AWS pipeline that scans and alerts on uploaded files based on a set of
@@ -230,7 +231,7 @@ View Chinese translation: [恶意软件分析大合集.md](恶意软件分析大
 * [Loki](https://github.com/Neo23x0/Loki) - Host based scanner for IOCs.
 * [Malfunction](https://github.com/Dynetics/Malfunction) - Catalog and
   compare malware at a function level.
-* [Manalyze](https://github.com/JusticeRage/Manalyze) - Static analyzer for PE 
+* [Manalyze](https://github.com/JusticeRage/Manalyze) - Static analyzer for PE
 executables.
 * [MASTIFF](https://github.com/KoreLogicSecurity/mastiff) - Static analysis
   framework.
@@ -305,14 +306,14 @@ executables.
   the configuration settings from common malwares.
 * [Malwr](https://malwr.com/) - Free analysis with an online Cuckoo Sandbox
   instance.
-* [MetaDefender Cloud](https://metadefender.opswat.com/ ) - Scan a file, hash, IP, URL or 
+* [MetaDefender Cloud](https://metadefender.opswat.com/ ) - Scan a file, hash, IP, URL or
   domain address for malware for free.
 * [NetworkTotal](https://www.networktotal.com/index.html) - A service that analyzes
   pcap files and facilitates the quick detection of viruses, worms, trojans, and all
   kinds of malware using Suricata configured with EmergingThreats Pro.
 * [Noriben](https://github.com/Rurik/Noriben) - Uses Sysinternals Procmon to
   collect information about malware in a sandboxed environment.
-* [PacketTotal](https://packettotal.com/) - PacketTotal is an online engine for analyzing .pcap files, and visualizing the network traffic within. 
+* [PacketTotal](https://packettotal.com/) - PacketTotal is an online engine for analyzing .pcap files, and visualizing the network traffic within.
 * [PDF Examiner](http://www.pdfexaminer.com/) - Analyse suspicious PDF files.
 * [ProcDot](http://www.procdot.com) - A graphical malware analysis tool kit.
 * [Recomposer](https://github.com/secretsquirrel/recomposer) - A helper
@@ -361,7 +362,7 @@ executables.
   accounts.
 * [PhishStats](https://phishstats.info/) - Phishing Statistics with search for
   IP, domain and website title
-* [SecurityTrails](https://securitytrails.com/) - Historical and current WHOIS, 
+* [SecurityTrails](https://securitytrails.com/) - Historical and current WHOIS,
   historical and current DNS records, similar domains, certificate information
   and other domain and IP related API and tools.
 * [SpamCop](https://www.spamcop.net/bl.shtml) - IP based spam block list.
@@ -453,7 +454,7 @@ the [browser malware](#browser-malware) section.*
   Event Log files from raw binary data.
 * [Foremost](http://foremost.sourceforge.net/) - File carving tool designed
   by the US Air Force.
-* [hachoir3](https://github.com/vstinner/hachoir3) - Hachoir is a Python library 
+* [hachoir3](https://github.com/vstinner/hachoir3) - Hachoir is a Python library
   to view and edit a binary stream field by field.
 * [Scalpel](https://github.com/sleuthkit/scalpel) - Another data carving
   tool.
@@ -479,7 +480,7 @@ the [browser malware](#browser-malware) section.*
   XOR key using frequency analysis.
 * [PackerAttacker](https://github.com/BromiumLabs/PackerAttacker) - A generic
   hidden code extractor for Windows malware.
-* [un{i}packer](https://github.com/unipacker/unipacker) - Automatic and 
+* [un{i}packer](https://github.com/unipacker/unipacker) - Automatic and
   platform-independent unpacker for Windows binaries based on emulation.
 * [unpacker](https://github.com/malwaremusings/unpacker/) - Automated malware
   unpacker for Windows malware based on WinAppDbg.
@@ -517,7 +518,7 @@ the [browser malware](#browser-malware) section.*
 * [codebro](https://github.com/hugsy/codebro) - Web based code browser using
   clang to provide basic code analysis.
 * [Cutter](https://github.com/radareorg/cutter) - GUI for Radare2.
-* [DECAF (Dynamic Executable Code Analysis Framework)](https://github.com/sycurelab/DECAF) 
+* [DECAF (Dynamic Executable Code Analysis Framework)](https://github.com/sycurelab/DECAF)
   - A binary analysis platform based   on QEMU. DroidScope is now an extension to DECAF.
 * [dnSpy](https://github.com/0xd4d/dnSpy) - .NET assembly editor, decompiler
   and debugger.
@@ -549,7 +550,7 @@ the [browser malware](#browser-malware) section.*
 * [LIEF](https://lief.quarkslab.com/) - LIEF provides a cross-platform library
   to parse, modify and abstract ELF, PE and MachO formats.
 * [ltrace](http://ltrace.org/) - Dynamic analysis for Linux executables.
-* [mac-a-mal](https://github.com/phdphuc/mac-a-mal) - An automated framework 
+* [mac-a-mal](https://github.com/phdphuc/mac-a-mal) - An automated framework
   for mac malware hunting.
 * [objdump](https://en.wikipedia.org/wiki/Objdump) - Part of GNU binutils,
   for static analysis of Linux binaries.
@@ -790,6 +791,9 @@ the [browser malware](#browser-malware) section.*
 
 * [APT Notes](https://github.com/aptnotes/data) - A collection of papers
   and notes related to Advanced Persistent Threats.
+* [Ember](https://github.com/endgameinc/ember) - Endgame Malware BEnchmark for Research,
+  a repository that makes it easy to (re)create a machine learning model that can be used
+  to predict a score for a PE file based on static analysis.
 * [File Formats posters](https://github.com/corkami/pics) - Nice visualization
   of commonly used file format (including PE & ELF).
 * [Honeynet Project](http://honeynet.org/) - Honeypot tools, papers, and
@@ -809,6 +813,8 @@ the [browser malware](#browser-malware) section.*
   link in description.
 * [Malware Samples and Traffic](http://malware-traffic-analysis.net/) - This
   blog focuses on network traffic related to malware infections.
+* [Malware Search+++](https://addons.mozilla.org/fr/firefox/addon/malware-search-plusplusplus/) Firefox extension allows
+  you to easily search some of the most popular malware databases
 * [Practical Malware Analysis Starter Kit](https://bluesoul.me/practical-malware-analysis-starter-kit/) -
   This package contains most of the software referenced in the Practical Malware
   Analysis book.
@@ -825,10 +831,6 @@ the [browser malware](#browser-malware) section.*
 * [/r/Malware](https://www.reddit.com/r/Malware) - The malware subreddit.
 * [/r/ReverseEngineering](https://www.reddit.com/r/ReverseEngineering) -
   Reverse engineering subreddit, not limited to just malware.
-* [Ember](https://github.com/endgameinc/ember) - Endgame Malware BEnchmark for Research,
-  a repository that makes it easy to (re)create a machine learning model that can be used
-  to predict a score for a PE file based on static analysis.
-
 
 
 


### PR DESCRIPTION
Hi,

I deleted malwaredb from malekal because the project seems abandoned. 
I suggest SystemLookup.com and the Firefox Malware Search++++ extension.
If you are interested in these changes, I am unfortunately not able to do the Chinese translations.

Thank you again for this incredible collection of resources about malware.