### PR TITLE
Updating dead link for packerid

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ executables.
 * [Nauz File Detector(NFD)](https://github.com/horsicq/Nauz-File-Detector) - Linker/Compiler/Tool detector  for Windows, Linux and MacOS.
 * [nsrllookup](https://github.com/rjhansen/nsrllookup) - A tool for looking
   up hashes in NIST's National Software Reference Library database.
-* [packerid](http://handlers.sans.org/jclausing/packerid.py) - A cross-platform
+* [packerid](https://github.com/sooshie/packerid) - A cross-platform
   Python alternative to PEiD.
 * [PE-bear](https://hshrzd.wordpress.com/pe-bear/) - Reversing tool for PE
   files.


### PR DESCRIPTION
Hey @rshipp 

original site is down, this is fork on GitHub.

Cheers!