### PR TITLE
openmalware.org domain is for sale

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ View Chinese translation: [恶意软件分析大合集.md](恶意软件分析大
   rapid identification and actionable context for malware investigations.
 * [Malshare](https://malshare.com) - Large repository of malware actively
   scrapped from malicious sites.
-* [Open Malware Project](http://openmalware.org/) - Sample information and
-  downloads. Formerly Offensive Computing.
 * [Ragpicker](https://github.com/robbyFux/Ragpicker) - Plugin based malware
   crawler with pre-analysis and reporting functionalities
 * [theZoo](https://github.com/ytisf/theZoo) - Live malware samples for


### PR DESCRIPTION
The Open Malware Project which links to http://openmalware.org/ is not a functioning website.