### PR TITLE
Added Suricata and DNSdumpster rools

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ executables.
   much metadata as possible for a website and to assess its good standing.
 * [Dig](https://networking.ringofsaturn.com/) - Free online dig and other
   network tools.
+* [DNSdumpster](https://dnsdumpster.com/) - Online tool to lookup DNS records.
 * [dnstwist](https://github.com/elceef/dnstwist) - Domain name permutation
   engine for detecting typo squatting, phishing and corporate espionage.
 * [IPinfo](https://github.com/hiddenillusion/IPinfo) - Gather information
@@ -704,8 +705,9 @@ the [browser malware](#browser-malware) section.*
   designed to analyze a web-based network traffic to detect central command
   and control (C&C) servers and malicious sites, using Squid proxy server and
   Spamhaus.
+* [Suricata](https://suricata.io/) -  A deep packet inspector and pattern matching IDS/IPS.
 * [Tcpdump](http://www.tcpdump.org/) - Collect network traffic.
-* [tcpick](http://tcpick.sourceforge.net/) - Trach and reassemble TCP streams
+* [tcpick](http://tcpick.sourceforge.net/) - Track and reassemble TCP streams
   from network traffic.
 * [tcpxtract](http://tcpxtract.sourceforge.net/) - Extract files from network
   traffic.


### PR DESCRIPTION
Suricata is a Bro/Zeek alternative that acts as an IDS/IPS. DNSdumpster is a tool that I use regularly for domain recon. Also, I fixed a typo under tcpick from "Trach" to "Track and reassamble" Thanks!